### PR TITLE
add real dry run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ FLAGS:
     -k, --mkdir        Recursively creates all parent directories of '<OUTPUT>' if they are missing
     -w, --overwrite    Overwrites output files, otherwise, a '_' is prepended to filename
     -p, --print        Prints the map table to stdout
-    -t, --test         Runs in test mode without renaming actual files (dry-run)
+    -t, --test         Runs in test mode without renaming actual files [aliases: dry-run]
+        --dry-run      Alias for --test
     -V, --version      Prints version information
 
 OPTIONS:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 )]
 pub struct Cli {
     /// Runs in test mode without renaming actual files
-    #[arg(short, long, visible_alias="dry-run")]
+    #[arg(short, long, visible_alias = "dry-run")]
     pub test: bool,
     /// Recursively creates all parent directories of '<OUTPUT>' if they are missing.
     #[arg(short = 'k', long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
     next_display_order = None,
 )]
 pub struct Cli {
-    /// Runs in test mode without renaming actual files (dry-run).
-    #[arg(short, long)]
+    /// Runs in test mode without renaming actual files
+    #[arg(short, long, visible_alias="dry-run")]
     pub test: bool,
     /// Recursively creates all parent directories of '<OUTPUT>' if they are missing.
     #[arg(short = 'k', long)]


### PR DESCRIPTION
Add an alias to `-t` to have a `--dry-run` option


![image](https://github.com/user-attachments/assets/7b397ebe-b44d-45f4-ab7e-f10551be303b)